### PR TITLE
feat(loader): upgrade purgecss to version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ module.exports = {
             loader: '@americanexpress/purgecss-loader',
             options: {
               paths: [path.join(somePath, 'src/**/*.{js,jsx}')],
-              whitelistPatternsChildren: [/:global$/],
+              safelist: [/:global$/],
             },
           },
         ],
@@ -82,9 +82,8 @@ the example to express this loader's compatibility.
 | `fontFace`   | `boolean` (default: false) see [options]     | `false`  |
 | `keyframes`  | `boolean` (default: false) see [options] | `false`  |
 | `variables`  | `boolean` (default: false) see [options] | `false`  |
-| `whitelist`  | `string[]` see [options]| `false`  |
-| `whitelistPatterns` | `Array<RegExp>` see [options] | `false`  |
-| `whitelistPatternsChildren` | `Array<RegExp>` see [options] | `false`  |
+| `safelist`  | `UserDefinedSafelist` see [options]| `false`  |
+| `blocklist` | `StringRegExpArray` see [options] | `false`  |
 
 [glob]: https://github.com/isaacs/node-glob
 [purgecss extractors]: https://www.purgecss.com/extractors.html

--- a/__fixtures__/root.scss
+++ b/__fixtures__/root.scss
@@ -16,7 +16,7 @@
   .isUsed {
     color: #00175a;
   }
-  .notUsed {
+  .isNotUsed {
     color: red;
   }
 }

--- a/__tests__/loader.spec.js
+++ b/__tests__/loader.spec.js
@@ -21,7 +21,7 @@ jest.setTimeout(10000);
 
 const runLoader = ({
   entry = '../__fixtures__/Component.jsx',
-} = {}) => {
+} = {}, safelist) => {
   const compiler = webpack({
     context: __dirname,
     entry,
@@ -57,7 +57,7 @@ const runLoader = ({
               loader: path.resolve(__dirname, '../loader.js'),
               options: {
                 paths: [path.resolve(__dirname, '../__fixtures__/**/*.{js,jsx}')],
-                whitelistPatternsChildren: [/:global$/],
+                safelist,
               },
             },
           ],
@@ -95,9 +95,9 @@ describe('purgecss loader', () => {
     expect(output).toContain('isUsed');
   });
 
-  it('should not strip global classes', async () => {
+  it('should not strip safelisted global classes', async () => {
     const componentEntry = { entry: '../__fixtures__/ComponentGlobal.jsx' };
-    const stats = await runLoader(componentEntry);
+    const stats = await runLoader(componentEntry, [/:global$/]);
     const { modules } = stats.toJson();
     const cssModuleIndex = findIndex(modules, {
       name: '../node_modules/css-loader??ref--5-1!../loader.js??ref--5-2!../__fixtures__/root.scss',

--- a/loader.js
+++ b/loader.js
@@ -17,8 +17,8 @@ const { getOptions } = require('loader-utils');
 
 module.exports = async function purifyCssLoader(content) {
   const {
-    paths, extractors = [], fontFace = false, keyframes = false, variables = false, whitelist,
-    whitelistPatterns, whitelistPatternsChildren,
+    paths, extractors = [], fontFace = false, keyframes = false, variables = false, safelist = [],
+    blocklist = [],
   } = getOptions(this);
   const purgeCSSResult = await new PurgeCSS().purge({
     content: paths,
@@ -27,9 +27,8 @@ module.exports = async function purifyCssLoader(content) {
     fontFace,
     keyframes,
     variables,
-    whitelist,
-    whitelistPatterns,
-    whitelistPatternsChildren,
+    safelist,
+    blocklist,
   });
   return purgeCSSResult[0].css;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "loader-utils": "^1.4.2",
-        "purgecss": "^2.1.2"
+        "purgecss": "^3.1.3"
       },
       "devDependencies": {
         "@babel/core": "^7.10.1",
@@ -2502,6 +2502,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -4493,6 +4494,7 @@
     },
     "node_modules/chalk": {
       "version": "2.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -4952,6 +4954,7 @@
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -4959,6 +4962,7 @@
     },
     "node_modules/color-name": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -4988,8 +4992,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "5.1.0",
-      "license": "MIT",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha1-B5LraC37wyWZm7K4T93duhEKxzw=",
       "engines": {
         "node": ">= 6"
       }
@@ -6376,6 +6381,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -7909,6 +7915,7 @@
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -11958,6 +11965,17 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha1-cwtn480J4t6s8DwCfIHJ2dvF6Ks=",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/nanomatch": {
       "version": "1.2.13",
       "dev": true,
@@ -15590,7 +15608,6 @@
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -16423,32 +16440,30 @@
       }
     },
     "node_modules/purgecss": {
-      "version": "2.3.0",
-      "license": "MIT",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-3.1.3.tgz",
+      "integrity": "sha1-Jph+wJ0S7q3DGOIvblqesL4JT0E=",
       "dependencies": {
-        "commander": "^5.0.0",
+        "commander": "^6.0.0",
         "glob": "^7.0.0",
-        "postcss": "7.0.32",
+        "postcss": "^8.2.1",
         "postcss-selector-parser": "^6.0.2"
       },
       "bin": {
-        "purgecss": "bin/purgecss"
+        "purgecss": "bin/purgecss.js"
       }
     },
     "node_modules/purgecss/node_modules/postcss": {
-      "version": "7.0.32",
-      "license": "MIT",
+      "version": "8.4.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
       "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       },
       "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/postcss"
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/purgecss/node_modules/postcss-selector-parser": {
@@ -16460,23 +16475,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/purgecss/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/purgecss/node_modules/supports-color": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/q": {
@@ -17746,6 +17744,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha1-rbw2HZxi3zgBJefxYfccgm8eSQw=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-resolve": {
       "version": "0.5.3",
       "dev": true,
@@ -18216,6 +18222,7 @@
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/americanexpress/purgecss-loader#readme",
   "dependencies": {
     "loader-utils": "^1.4.2",
-    "purgecss": "^2.1.2"
+    "purgecss": "^3.1.3"
   },
   "devDependencies": {
     "@babel/core": "^7.10.1",


### PR DESCRIPTION
BREAKING CHANGE: various whitelist options replaced with safelist

## Description
Upgrade purgecss to version 3.

## Motivation and Context

Fixes https://github.com/americanexpress/purgecss-loader/issues/54

Release notes for purgecss 3, which describe the change from whitelist to safelist:
https://github.com/FullHuman/purgecss/releases/tag/v3.0.0

I didn't go higher than v3 because of additional breaking changes.

## How Has This Been Tested?
Updated unit tests to pass.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Purgecss-Loader?
This resolves a security issue.  Developers will need to update their configurations.